### PR TITLE
Bump express-serverless version from 0.1.1 to 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Merged pull requests:**
 
+- Feature/readme [\#3](https://github.com/airscholar/heroku-express-serverless/pull/3) ([airscholar](https://github.com/airscholar))
 - Bump express-serverless version from 0.0.0 to 0.1.0 [\#2](https://github.com/airscholar/heroku-express-serverless/pull/2) ([airscholar](https://github.com/airscholar))
 - Bump express-serverless version with readme [\#1](https://github.com/airscholar/heroku-express-serverless/pull/1) ([airscholar](https://github.com/airscholar))
 


### PR DESCRIPTION
# Changelog

## [Unreleased](https://github.com/airscholar/heroku-express-serverless/tree/HEAD)

[Full Changelog](https://github.com/airscholar/heroku-express-serverless/compare/04ff230cb3d85b982648d0be492e02f4d2eccba0...HEAD)

**Merged pull requests:**

- Feature/readme [\#3](https://github.com/airscholar/heroku-express-serverless/pull/3) ([airscholar](https://github.com/airscholar))
- Bump express-serverless version from 0.0.0 to 0.1.0 [\#2](https://github.com/airscholar/heroku-express-serverless/pull/2) ([airscholar](https://github.com/airscholar))
- Bump express-serverless version with readme [\#1](https://github.com/airscholar/heroku-express-serverless/pull/1) ([airscholar](https://github.com/airscholar))



\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*
