### PR TITLE
Bump express-serverless version from 0.1.2 to 0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 **Merged pull requests:**
 
+- Bump express-serverless version from 0.1.1 to 0.1.2 [\#5](https://github.com/airscholar/heroku-express-serverless/pull/5) ([airscholar](https://github.com/airscholar))
+- Bump express-serverless version from 0.1.0 to 0.1.1 [\#4](https://github.com/airscholar/heroku-express-serverless/pull/4) ([airscholar](https://github.com/airscholar))
 - Feature/readme [\#3](https://github.com/airscholar/heroku-express-serverless/pull/3) ([airscholar](https://github.com/airscholar))
 - Bump express-serverless version from 0.0.0 to 0.1.0 [\#2](https://github.com/airscholar/heroku-express-serverless/pull/2) ([airscholar](https://github.com/airscholar))
 - Bump express-serverless version with readme [\#1](https://github.com/airscholar/heroku-express-serverless/pull/1) ([airscholar](https://github.com/airscholar))


### PR DESCRIPTION
# Changelog

## [Unreleased](https://github.com/airscholar/heroku-express-serverless/tree/HEAD)

[Full Changelog](https://github.com/airscholar/heroku-express-serverless/compare/04ff230cb3d85b982648d0be492e02f4d2eccba0...HEAD)

**Merged pull requests:**

- Bump express-serverless version from 0.1.1 to 0.1.2 [\#5](https://github.com/airscholar/heroku-express-serverless/pull/5) ([airscholar](https://github.com/airscholar))
- Bump express-serverless version from 0.1.0 to 0.1.1 [\#4](https://github.com/airscholar/heroku-express-serverless/pull/4) ([airscholar](https://github.com/airscholar))
- Feature/readme [\#3](https://github.com/airscholar/heroku-express-serverless/pull/3) ([airscholar](https://github.com/airscholar))
- Bump express-serverless version from 0.0.0 to 0.1.0 [\#2](https://github.com/airscholar/heroku-express-serverless/pull/2) ([airscholar](https://github.com/airscholar))
- Bump express-serverless version with readme [\#1](https://github.com/airscholar/heroku-express-serverless/pull/1) ([airscholar](https://github.com/airscholar))



\* *This Changelog was automatically generated by [github_changelog_generator](https://github.com/github-changelog-generator/github-changelog-generator)*
