### PR TITLE
Bump express-serverless version from 0.1.3 to 0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 **Merged pull requests:**
 
+- Bump express-serverless version from 0.1.2 to 0.1.3 [\#6](https://github.com/airscholar/heroku-express-serverless/pull/6) ([airscholar](https://github.com/airscholar))
 - Bump express-serverless version from 0.1.1 to 0.1.2 [\#5](https://github.com/airscholar/heroku-express-serverless/pull/5) ([airscholar](https://github.com/airscholar))
 - Bump express-serverless version from 0.1.0 to 0.1.1 [\#4](https://github.com/airscholar/heroku-express-serverless/pull/4) ([airscholar](https://github.com/airscholar))
 - Feature/readme [\#3](https://github.com/airscholar/heroku-express-serverless/pull/3) ([airscholar](https://github.com/airscholar))


### PR DESCRIPTION
IMPORTANT: Only merge if the platform build is passing!

Changelog:

https://github.com/airscholar/heroku-express-serverless/commit/38a28542652386bda57cbf2bedd5d70dc443e3f8 Update (https://github.com/airscholar/heroku-express-serverless/pull/6)

Instructions:

SQUASH MERGE this PR - this is necessary to ensure the automated Create Release action is triggered.
Double check that the Create Release action was triggered and ran successfully on the commit to master (this should only take a few seconds).
If the Create Release action failed due to a transient issue, retry the action. If it failed due to a non-transient issue, you will need to manually create a release by following these steps:
Pull most recent version of master
Run ./tools/bin/tag_version.sh
Create a GitHub release with the changelog